### PR TITLE
Change default editor to Zed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ it defaults to the name of the authenticating user.
 
 Pass `--open` to open the project after cloning. 
 The editor command can be configured via `--editor COMMAND` or the `GH_DEVCLONE_EDITOR` environment variable. 
-The default editor is `idea`.
+The default editor is `zed`.
 
 ```bash
 # --open is a simple flag; it can appear before or after OWNER/REPO

--- a/gh-devclone
+++ b/gh-devclone
@@ -46,7 +46,7 @@ argparser.add_argument(
     "--editor",
     action=EnvDefault,
     envvar="GH_DEVCLONE_EDITOR",
-    default="idea",
+    default="zed",
     help="editor command to open the project [env: GH_DEVCLONE_EDITOR=] [default: %(default)s]",
 )
 


### PR DESCRIPTION
Change the default editor from `idea` to `zed` in both the CLI and README.